### PR TITLE
Bugfix/project filter

### DIFF
--- a/client/src/hooks/useAPI.ts
+++ b/client/src/hooks/useAPI.ts
@@ -1,36 +1,47 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { IProject, IResume, IResumeMetadata } from '../types/api_types';
 
 const RESUMES_ENDPOINT = 'resumes';
 const PROJECTS_ENDPOINT = 'projects';
 
 // base GET request function
-const getRequest = async (url: string) => {
+const getRequest = async (url: string, signal: AbortSignal) => {
   url = encodeURI(url);
-  const response = await fetch(url);
+  const response = await fetch(url, { signal });
   const data = await response.json();
   return data;
 };
 
 // get all resumes
-const getResumes = async (baseURL: string): Promise<IResumeMetadata[]> => {
-  const data = await getRequest(`${baseURL}/${RESUMES_ENDPOINT}`);
+const getResumes = async (
+  signal: AbortSignal,
+  baseURL: string
+): Promise<IResumeMetadata[]> => {
+  const data = await getRequest(`${baseURL}/${RESUMES_ENDPOINT}`, signal);
   return data;
 };
 
 // get all projects
 const getProjects = async (
+  signal: AbortSignal,
   baseURL: string,
   filters?: string
 ): Promise<IProject[]> => {
   filters = filters ? `?filters=${filters}` : '';
-  const data = await getRequest(`${baseURL}/${PROJECTS_ENDPOINT}${filters}`);
+  const data = await getRequest(
+    `${baseURL}/${PROJECTS_ENDPOINT}${filters}`,
+    signal
+  );
   return data;
 };
 
 // get a single resume
-const getResume = async (baseURL: string, id: string): Promise<IResume> => {
-  const data = await getRequest(`${baseURL}/${RESUMES_ENDPOINT}/${id}`);
+const getResume = async (
+  signal: AbortSignal,
+  baseURL: string,
+  id: string
+): Promise<IResume> => {
+  const data = await getRequest(`${baseURL}/${RESUMES_ENDPOINT}/${id}`, signal);
   return data;
 };
 
@@ -47,14 +58,26 @@ const getBaseURL = (): string => {
  */
 export const useAPI = () => {
   const base_api_url = getBaseURL();
+  const abortControllers = useRef(new Map<string, AbortController>());
+  const createAbortController = (key: string) => {
+    if (abortControllers.current.has(key)) {
+      abortControllers.current.get(key)!.abort();
+    }
+    const controller = new AbortController();
+    abortControllers.current.set(key, controller);
+    return controller;
+  };
+
   const fetchAllResumes = useCallback(async () => {
-    const resumes = await getResumes(base_api_url);
+    const controller = createAbortController('fetchAllResumes');
+    const resumes = await getResumes(controller.signal, base_api_url);
     return resumes;
   }, [base_api_url]);
 
   const fetchResumeDetails = useCallback(
     async (id: string) => {
-      const resume = await getResume(base_api_url, id);
+      const controller = createAbortController('fetchResumeDetails');
+      const resume = await getResume(controller.signal, base_api_url, id);
       return resume;
     },
     [base_api_url]
@@ -62,7 +85,12 @@ export const useAPI = () => {
 
   const fetchAllProjects = useCallback(
     async (filters?: string) => {
-      const projects = await getProjects(base_api_url, filters);
+      const controller = createAbortController('fetchAllProjects');
+      const projects = await getProjects(
+        controller.signal,
+        base_api_url,
+        filters
+      );
       return projects;
     },
     [base_api_url]

--- a/client/src/hooks/useProjects.ts
+++ b/client/src/hooks/useProjects.ts
@@ -23,8 +23,8 @@ const useProjects = (role?: ResumeRole) => {
   const [projects, projectsDispatch] = useProjectsState();
 
   useEffect(() => {
-    const getProjects = async (filters: string | undefined) => {
-      const projectsFromServer = await fetchAllProjects(filters);
+    const getProjects = async () => {
+      const projectsFromServer = await fetchAllProjects(role);
       projectsFromServer &&
         projectsDispatch({
           type: 'SET_PROJECT_LIST',
@@ -44,7 +44,7 @@ const useProjects = (role?: ResumeRole) => {
           }),
         });
     };
-    getProjects(role);
+    getProjects();
   }, [fetchAllProjects, projectsDispatch, role]);
 
   return { projects, loading: loadingProjects, error: errorProjects };

--- a/client/src/hooks/useProjects.ts
+++ b/client/src/hooks/useProjects.ts
@@ -3,6 +3,7 @@ import {
   ProjectsContext,
   ProjectsDispatchContext,
 } from '../projects/ProjectsContext';
+import { ResumeRole } from '../types/resume';
 import useAPIWithErrorHandling from './useAPIWithErrorHandling';
 
 export const useProjectsState = () => {
@@ -16,16 +17,13 @@ export const useProjectsState = () => {
   return [projects, projectsDispatch] as const;
 };
 
-const useProjects = (filters?: string) => {
+const useProjects = (role?: ResumeRole) => {
   const { fetchAllProjects, loadingProjects, errorProjects } =
     useAPIWithErrorHandling();
   const [projects, projectsDispatch] = useProjectsState();
 
   useEffect(() => {
-    const getProjects = async () => {
-      if (projects.length > 0) {
-        return;
-      }
+    const getProjects = async (filters: string | undefined) => {
       const projectsFromServer = await fetchAllProjects(filters);
       projectsFromServer &&
         projectsDispatch({
@@ -46,8 +44,8 @@ const useProjects = (filters?: string) => {
           }),
         });
     };
-    getProjects();
-  }, [projects, fetchAllProjects, projectsDispatch, filters]);
+    getProjects(role);
+  }, [fetchAllProjects, projectsDispatch, role]);
 
   return { projects, loading: loadingProjects, error: errorProjects };
 };

--- a/client/src/hooks/useWithErrorHandling.ts
+++ b/client/src/hooks/useWithErrorHandling.ts
@@ -1,5 +1,7 @@
 import { useCallback, useState } from 'react';
 
+const ERROR_NAMES_TO_IGNORE = ['AbortError'];
+
 const useWithErrorHandling = <TArgs extends any[], TResponse>(
   fn: (...args: TArgs) => Promise<TResponse>,
   defaultError = 'Error'
@@ -16,6 +18,10 @@ const useWithErrorHandling = <TArgs extends any[], TResponse>(
         setLoading(false);
         return response;
       } catch (err: unknown) {
+        // ignore abort errors and continue loading
+        if (err instanceof Error && ERROR_NAMES_TO_IGNORE.includes(err.name)) {
+          return null;
+        }
         setLoading(false);
         if (err instanceof Error) {
           setError(err.message);


### PR DESCRIPTION
# Fix Project Filtering and Add Request Cancellation

## Changes

This PR fixes the Project level filters and adds `AbortController` support to our API requests.

### Main Changes
- Added request cancellation capability to all API request functions using `AbortController`
- Updated `useProjects` hook to properly filter projects by role
